### PR TITLE
Cyclic symlink workaround

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1627,8 +1627,10 @@ void TrackDAO::markTrackLocationsAsDeleted(const QString& directory) {
 // files size exists in the track_locations table. That means the file has
 // moved instead of being deleted outright, and so we can salvage your
 // existing metadata that you have in your DB (like cue points, etc.).
-bool TrackDAO::detectMovedFiles(QSet<int>* pTracksMovedSetOld,
-        QSet<int>* pTracksMovedSetNew, volatile const bool* pCancel) {
+bool TrackDAO::detectMovedTracks(QSet<int>* pTracksMovedSetOld,
+        QSet<int>* pTracksMovedSetNew,
+        const QStringList& addedTracks,
+        volatile const bool* pCancel) {
     // This function should not start a transaction on it's own!
     // When it's called from libraryscanner.cpp, there already is a transaction
     // started!

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -152,7 +152,9 @@ class TrackDAO : public QObject, public virtual DAO {
     void markTrackLocationsAsDeleted(const QString& directory);
     bool detectMovedFiles(QSet<int>* pTracksMovedSetOld,
             QSet<int>* pTracksMovedSetNew, volatile const bool* pCancel);
-    bool verifyRemainingTracks(volatile const bool* pCancel);
+    bool verifyRemainingTracks(
+            const QStringList& libraryRootDirs,
+            volatile const bool* pCancel);
     void detectCoverArtForUnknownTracks(volatile const bool* pCancel,
                                         QSet<int>* pTracksChanged);
 

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -154,6 +154,7 @@ class TrackDAO : public QObject, public virtual DAO {
                           QSet<int>* pTracksMovedSetNew,
                           const QStringList& addedTracks,
                           volatile const bool* pCancel);
+
     bool verifyRemainingTracks(
             const QStringList& libraryRootDirs,
             volatile const bool* pCancel);

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -150,8 +150,10 @@ class TrackDAO : public QObject, public virtual DAO {
     void invalidateTrackLocationsInLibrary();
     void markUnverifiedTracksAsDeleted();
     void markTrackLocationsAsDeleted(const QString& directory);
-    bool detectMovedFiles(QSet<int>* pTracksMovedSetOld,
-            QSet<int>* pTracksMovedSetNew, volatile const bool* pCancel);
+    bool detectMovedTracks(QSet<int>* pTracksMovedSetOld,
+                          QSet<int>* pTracksMovedSetNew,
+                          const QStringList& addedTracks,
+                          volatile const bool* pCancel);
     bool verifyRemainingTracks(
             const QStringList& libraryRootDirs,
             volatile const bool* pCancel);

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -12,8 +12,10 @@ ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
                                  const QLinkedList<QFileInfo>& filesToImport,
                                  const QLinkedList<QFileInfo>& possibleCovers,
                                  SecurityTokenPointer pToken)
-        : ScannerTask(pScanner, scannerGlobal), m_dirPath(dirPath),
-          m_prevHashExists(prevHashExists), m_newHash(newHash),
+        : ScannerTask(pScanner, scannerGlobal),
+          m_dirPath(dirPath),
+          m_prevHashExists(prevHashExists),
+          m_newHash(newHash),
           m_filesToImport(filesToImport),
           m_possibleCovers(possibleCovers),
           m_pToken(pToken) {

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -256,7 +256,12 @@ void LibraryScanner::slotStartScan() {
 
 // is called when all tasks of the first stage are done (threads are finished)
 void LibraryScanner::slotFinishHashedScan() {
-    if (m_scannerGlobal.isNull() || m_scannerGlobal->unhashedDirs().empty()) {
+    qDebug() << "LibraryScanner::slotFinishHashedScan";
+    DEBUG_ASSERT_AND_HANDLE(!m_scannerGlobal.isNull()) {
+        qWarning() << "No scanner global state exists in LibraryScanner::slotFinishHashedScan";
+        return;
+    }
+    if (m_scannerGlobal->unhashedDirs().empty()) {
         // bypass the second stage
         slotFinishUnhashedScan();
     }

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -324,8 +324,6 @@ void LibraryScanner::cleanUpScan( const QStringList& verifiedTracks,
     //qDebug() << "Burn CPU";
     //for (int i = 0;i < 1000000000; i++) asm("nop");
 
-
-
     // Check to see if the "deleted" tracks showed up in another location,
     // and if so, do some magic to update all our tables.
     qDebug() << "Detecting moved files.";
@@ -536,9 +534,9 @@ void LibraryScanner::slotTrackExists(const QString& trackPath) {
 void LibraryScanner::slotAddNewTrack(TrackPointer pTrack) {
     //qDebug() << "LibraryScanner::slotAddNewTrack" << pTrack;
     ScopedTimer timer("LibraryScanner::addNewTrack");
-    // For statistics tracking.
+    // For statistics tracking and to detect moved tracks
     if (m_scannerGlobal) {
-        m_scannerGlobal->trackAdded();
+        m_scannerGlobal->trackAdded(pTrack->getLocation());
     }
     if (m_trackDao.addTracksAdd(pTrack.data(), false)) {
         // Successfully added. Signal the main instance of TrackDAO,

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -270,18 +270,13 @@ void LibraryScanner::slotFinishHashedScan() {
     connect(pWatcher, SIGNAL(allTasksDone()),
             this, SLOT(slotFinishUnhashedScan()));
 
-    foreach (const QString& dirPath, m_scannerGlobal->unhashedDirs()) {
-        // Acquire a security bookmark for this directory if we are in a
-        // sandbox. For speed we avoid opening security bookmarks when recursive
-        // scanning so that relies on having an open bookmark for the containing
-        // directory.
-        MDir dir(dirPath);
+    foreach (const DirInfo& dirInfo, m_scannerGlobal->unhashedDirs()) {
         // no testAndMarkDirectoryScanned() here, because all unhashedDirs()
         // are already tracked
         queueTask(new RecursiveScanDirectoryTask(this, m_scannerGlobal,
-                                                     dir.dir(),
-                                                     dir.token(),
-                                                     true));
+                                                 dirInfo.dir(),
+                                                 dirInfo.token(),
+                                                 true));
     }
 }
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -240,9 +240,11 @@ void LibraryScanner::slotStartScan() {
         // scanning so that relies on having an open bookmark for the containing
         // directory.
         MDir dir(dirPath);
-        queueTask(new RecursiveScanDirectoryTask(this, m_scannerGlobal,
-                                                 dir.dir(),
-                                                 dir.token()));
+        if (!m_scannerGlobal->testAndMarkDirectoryScanned(dir.dir())) {
+            queueTask(new RecursiveScanDirectoryTask(this, m_scannerGlobal,
+                                                     dir.dir(),
+                                                     dir.token()));
+        }
     }
 }
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -331,7 +331,7 @@ void LibraryScanner::cleanUpScan() {
     qDebug() << "Detecting moved files.";
     QSet<int> tracksMovedSetOld;
     QSet<int> tracksMovedSetNew;
-    if (!m_trackDao.detectMovedFiles(&tracksMovedSetOld,
+    if (!m_trackDao.detectMovedTracks(&tracksMovedSetOld,
             &tracksMovedSetNew,
             m_scannerGlobal->addedTracks(),
             m_scannerGlobal->shouldCancelPointer())) {

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -120,8 +120,7 @@ class LibraryScanner : public QThread {
     // CANCELING -> IDLE
     bool changeScannerState(LibraryScanner::ScannerState newState);
 
-    void cleanUpScan(const QStringList& verifiedTracks,
-            const QStringList& verifiedDirectories);
+    void cleanUpScan();
 
     // The library trackcollection. Do not touch this from the library scanner
     // thread.

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -91,7 +91,6 @@ class LibraryScanner : public QThread {
     void slotFinishUnhashedScan();
 
     // ScannerTask signal handlers.
-    void slotTaskDone(bool success);
     void slotDirectoryHashedAndScanned(const QString& directoryPath,
                                    bool newDirectory, int hash);
     void slotDirectoryUnchanged(const QString& directoryPath);

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -87,7 +87,8 @@ class LibraryScanner : public QThread {
 
   private slots:
     void slotStartScan();
-    void slotFinishScan();
+    void slotFinishHashedScan();
+    void slotFinishUnhashedScan();
 
     // ScannerTask signal handlers.
     void slotTaskDone(bool success);

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -151,6 +151,8 @@ class LibraryScanner : public QThread {
     QSemaphore m_stateSema;
     // this is accessed main and LibraryScanner thread
     volatile ScannerState m_state;
+
+    QStringList m_libraryRootDirs;
 };
 
 #endif

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -93,7 +93,7 @@ void RecursiveScanDirectoryTask::run() {
                                             newHash, prevHashExists, filesToImport,
                                             possibleCovers, m_pToken));
             } else {
-                emit(directoryHashed(dirPath, !prevHashExists, newHash));
+                emit(directoryHashedAndScanned(dirPath, !prevHashExists, newHash));
             }
         } else {
             emit(directoryUnchanged(dirPath));

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -90,7 +90,7 @@ void RecursiveScanDirectoryTask::run() {
             if (!filesToImport.isEmpty()) {
                 m_pScanner->queueTask(
                         new ImportFilesTask(m_pScanner, m_scannerGlobal, dirPath,
-                                            newHash, prevHashExists, filesToImport,
+                                            prevHashExists, newHash, filesToImport,
                                             possibleCovers, m_pToken));
             } else {
                 emit(directoryHashedAndScanned(dirPath, !prevHashExists, newHash));

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -8,10 +8,11 @@
 
 RecursiveScanDirectoryTask::RecursiveScanDirectoryTask(
         LibraryScanner* pScanner, const ScannerGlobalPointer scannerGlobal,
-        const QDir& dir, SecurityTokenPointer pToken)
+        const QDir& dir, SecurityTokenPointer pToken, bool scanUnhashed)
         : ScannerTask(pScanner, scannerGlobal),
           m_dir(dir),
-          m_pToken(pToken) {
+          m_pToken(pToken),
+          m_scanUnhashed(scanUnhashed) {
 }
 
 void RecursiveScanDirectoryTask::run() {
@@ -80,7 +81,7 @@ void RecursiveScanDirectoryTask::run() {
     int prevHash = m_scannerGlobal->directoryHashInDatabase(dirPath);
     bool prevHashExists = prevHash != -1;
 
-    if (prevHashExists) {
+    if (prevHashExists || m_scanUnhashed) {
         // Compare the hashes, and if they don't match, rescan the files in that
         // directory!
         if (prevHash != newHash) {
@@ -109,7 +110,7 @@ void RecursiveScanDirectoryTask::run() {
         if (!m_scannerGlobal->testAndMarkDirectoryScanned(nextDir)) {
             m_pScanner->queueTask(
                     new RecursiveScanDirectoryTask(m_pScanner, m_scannerGlobal,
-                                                   nextDir, m_pToken));
+                                                   nextDir, m_pToken, m_scanUnhashed));
         }
     }
     setSuccess(true);

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -99,7 +99,7 @@ void RecursiveScanDirectoryTask::run() {
             emit(directoryUnchanged(dirPath));
         }
     } else {
-        m_scannerGlobal->addUnhashedDir(dirPath);
+        m_scannerGlobal->addUnhashedDir(m_dir, m_pToken);
     }
 
     // Process all of the sub-directories.

--- a/src/library/scanner/recursivescandirectorytask.h
+++ b/src/library/scanner/recursivescandirectorytask.h
@@ -18,7 +18,8 @@ class RecursiveScanDirectoryTask : public ScannerTask {
     RecursiveScanDirectoryTask(LibraryScanner* pScanner,
                                const ScannerGlobalPointer scannerGlobal,
                                const QDir& dir,
-                               SecurityTokenPointer pToken);
+                               SecurityTokenPointer pToken,
+                               bool scanUnhashed);
     virtual ~RecursiveScanDirectoryTask() {}
 
     virtual void run();
@@ -26,6 +27,7 @@ class RecursiveScanDirectoryTask : public ScannerTask {
   private:
     QDir m_dir;
     SecurityTokenPointer m_pToken;
+    bool m_scanUnhashed;
 };
 
 #endif /* RECURSIVESCANDIRECTORYTASK_H */

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -49,7 +49,6 @@ class ScannerGlobal {
               // Unless marked un-clean, we assume it will finish cleanly.
               m_scanFinishedCleanly(true),
               m_shouldCancel(false),
-              m_numAddedTracks(0),
               m_numScannedDirectories(0) {
     }
 
@@ -160,10 +159,10 @@ class ScannerGlobal {
     }
 
     int numAddedTracks() const {
-        return m_numAddedTracks;
+        return m_addedTracks.size();
     }
-    void trackAdded() {
-        m_numAddedTracks++;
+    void trackAdded(const QString& trackLocation) {
+        m_addedTracks << trackLocation;
     }
 
     int numScannedDirectories() const {
@@ -209,12 +208,14 @@ class ScannerGlobal {
     // The list of tracks verified by the scan.
     QStringList m_verifiedTracks;
 
+    // The list of tracks added by the scan.
+    QStringList m_addedTracks;
+
     volatile bool m_scanFinishedCleanly;
     volatile bool m_shouldCancel;
 
     // Stats tracking.
     PerformanceTimer m_timer;
-    int m_numAddedTracks;
     int m_numScannedDirectories;
 };
 

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -69,6 +69,10 @@ class ScannerGlobal {
         m_directoriesUnhashed.append(dirPath);
     }
 
+    inline QList<QString>& unhashedDirs() {
+        return m_directoriesUnhashed;
+    }
+
     // TODO(rryan) test whether tasks should create their own QRegExp.
     inline bool isAudioFileSupported(const QString& fileName) const {
         QMutexLocker locker(&m_supportedExtensionsMatcherMutex);

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -158,8 +158,8 @@ class ScannerGlobal {
         return m_timer.elapsed();
     }
 
-    int numAddedTracks() const {
-        return m_addedTracks.size();
+    const QStringList& addedTracks() const {
+        return m_addedTracks;
     }
     void trackAdded(const QString& trackLocation) {
         m_addedTracks << trackLocation;

--- a/src/library/scanner/scannerglobal.h
+++ b/src/library/scanner/scannerglobal.h
@@ -64,6 +64,11 @@ class ScannerGlobal {
         }
     }
 
+    inline void addUnhashedDir(const QString& dirPath) {
+        QMutexLocker locker(&m_directoriesUnhashedMutex);
+        m_directoriesUnhashed.append(dirPath);
+    }
+
     // TODO(rryan) test whether tasks should create their own QRegExp.
     inline bool isAudioFileSupported(const QString& fileName) const {
         QMutexLocker locker(&m_supportedExtensionsMatcherMutex);
@@ -154,9 +159,15 @@ class ScannerGlobal {
 
     // This set will grow during a scan by successively
     // inserting the canonical paths of directories that
-    // have already been scanned.
+    // are about to be scanned.
     mutable QMutex m_directoriesScannedMutex;
     QSet<QString> m_directoriesScanned;
+
+    // This set will collect all locations of new
+    // discovered directories, they are scanned in a
+    // second run to avoid swapping between duplicated tracks
+    mutable QMutex m_directoriesUnhashedMutex;
+    QList<QString> m_directoriesUnhashed;
 
     // Typically there are 1 to 2 entries in the blacklist so a O(n) search in a
     // QList may have better constant factors than a O(1) QSet check. However,

--- a/src/library/scanner/scannertask.cpp
+++ b/src/library/scanner/scannertask.cpp
@@ -10,5 +10,8 @@ ScannerTask::ScannerTask(LibraryScanner* pScanner,
 }
 
 ScannerTask::~ScannerTask() {
-    emit(taskDone(m_success));
+    if (!m_success) {
+    	m_scannerGlobal->clearScanFinishedCleanly();
+    }
+    m_scannerGlobal->getTaskWatcher().taskDone();
 }

--- a/src/library/scanner/scannertask.cpp
+++ b/src/library/scanner/scannertask.cpp
@@ -7,8 +7,6 @@ ScannerTask::ScannerTask(LibraryScanner* pScanner,
           m_scannerGlobal(scannerGlobal),
           m_success(false) {
     setAutoDelete(true);
-    connect(this, SIGNAL(directoryHashed(QString, bool, int)),
-            this, SIGNAL(directoryHashedAndScanned(QString, bool, int)));
 }
 
 ScannerTask::~ScannerTask() {

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -23,8 +23,6 @@ class ScannerTask : public QObject, public QRunnable {
     void queueTask(ScannerTask* pTask);
     void directoryHashedAndScanned(const QString& directoryPath,
                                    bool newDirectory, int hash);
-    void directoryHashed(const QString& directoryPath, bool newDirectory,
-                         int hash);
     void directoryUnchanged(const QString& directoryPath);
     void trackExists(const QString& filePath);
     void addNewTrack(TrackPointer pTrack);

--- a/src/util/task.cpp
+++ b/src/util/task.cpp
@@ -18,7 +18,7 @@ void TaskWatcher::watchTask(QObject* pTask, const char* doneSignal) {
 
     // Watch pTask for doneSignal. Use a DirectConnection since m_activeTasks is
     // an atomic integer.
-    connect(pTask, doneSignal, this, SLOT(taskDone()), Qt::DirectConnection);
+    connect(pTask, doneSignal, this, SLOT(taskDone()));
 }
 
 void TaskWatcher::taskDone() {

--- a/src/util/task.cpp
+++ b/src/util/task.cpp
@@ -12,13 +12,9 @@ TaskWatcher::~TaskWatcher() {
     }
 }
 
-void TaskWatcher::watchTask(QObject* pTask, const char* doneSignal) {
+void TaskWatcher::watchTask() {
     // Increment the number of active tasks.
     m_activeTasks.ref();
-
-    // Watch pTask for doneSignal. Use a DirectConnection since m_activeTasks is
-    // an atomic integer.
-    connect(pTask, doneSignal, this, SLOT(taskDone()));
 }
 
 void TaskWatcher::taskDone() {

--- a/src/util/task.h
+++ b/src/util/task.h
@@ -15,17 +15,16 @@ class TaskWatcher : public QObject {
     // Increment the number of active tasks by one and watch pTask for
     // doneSignal. This should be called before the task starts to prevent a
     // race condition where the task completes before we listen for doneSignal.
-    void watchTask(QObject* pTask, const char* doneSignal);
+    void watchTask();
 
-  signals:
-    // Signalled when all watched tasks are done from the thread that emitted
-    // the last taskDone() signal.
-    void allTasksDone();
-
-  private slots:
     // Called when an individual task is done.
     // WARNING: Invoked in the thread the task runs in.
     void taskDone();
+
+  signals:
+    // Signaled when all watched tasks are done from the thread that emitted
+    // the last taskDone() signal.
+    void allTasksDone();
 
   private:
     QAtomicInt m_activeTasks;


### PR DESCRIPTION
This is a PR, that features the behaviour discussed in 
https://github.com/mixxxdj/mixxx/pull/708

Tracks, previously discovered in duplicated directories are no treated as deleted. 
Scanning still rejects directories that are already track by their canonical path. 
In 1.11, duplicates where silently removed if one of the duplicated track is not reachable during the scan. This has changed in this PR, now a missing duplicated Track is listed as missing tracks as well.    