### PR TITLE
Restart webtask

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -88,7 +88,7 @@ void DlgTagFetcher::loadTrack(const TrackPointer& track) {
         return;
     }
     results->clear();
-    disconnect(track.get(),
+    disconnect(m_track.get(),
             &Track::changed,
             this,
             &DlgTagFetcher::slotTrackChanged);
@@ -96,7 +96,7 @@ void DlgTagFetcher::loadTrack(const TrackPointer& track) {
     m_track = track;
     m_data = Data();
     m_networkResult = NetworkResult::Ok;
-    m_tagFetcher.startFetch(m_track);
+    m_tagFetcher.startFetch(track);
 
     connect(track.get(),
             &Track::changed,

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -39,7 +39,8 @@ void TagFetcher::startFetch(
 void TagFetcher::abortAcoustIdTask() {
     if (m_pAcoustIdTask) {
         disconnect(m_pAcoustIdTask.get());
-        m_pAcoustIdTask->deleteBeforeFinished();
+        m_pAcoustIdTask->invokeAbort();
+        m_pAcoustIdTask->deleteLater();
         m_pAcoustIdTask = nullptr;
     }
 }
@@ -47,7 +48,8 @@ void TagFetcher::abortAcoustIdTask() {
 void TagFetcher::abortMusicBrainzTask() {
     if (m_pMusicBrainzTask) {
         disconnect(m_pMusicBrainzTask.get());
-        m_pMusicBrainzTask->deleteBeforeFinished();
+        m_pMusicBrainzTask->invokeAbort();
+        m_pMusicBrainzTask->deleteLater();
         m_pMusicBrainzTask = nullptr;
     }
 }
@@ -92,6 +94,10 @@ void TagFetcher::slotFingerprintReady() {
             this,
             &TagFetcher::slotAcoustIdTaskFailed);
     connect(m_pAcoustIdTask.get(),
+            &mixxx::AcoustIdLookupTask::aborted,
+            this,
+            &TagFetcher::slotAcoustIdTaskAborted);
+    connect(m_pAcoustIdTask.get(),
             &mixxx::AcoustIdLookupTask::networkError,
             this,
             &TagFetcher::slotAcoustIdTaskNetworkError);
@@ -128,6 +134,10 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
             this,
             &TagFetcher::slotMusicBrainzTaskFailed);
     connect(m_pMusicBrainzTask.get(),
+            &mixxx::MusicBrainzRecordingsTask::aborted,
+            this,
+            &TagFetcher::slotMusicBrainzTaskAborted);
+    connect(m_pMusicBrainzTask.get(),
             &mixxx::MusicBrainzRecordingsTask::networkError,
             this,
             &TagFetcher::slotMusicBrainzTaskNetworkError);
@@ -145,6 +155,10 @@ void TagFetcher::slotAcoustIdTaskFailed(
             -1);
 }
 
+void TagFetcher::slotAcoustIdTaskAborted() {
+    abortAcoustIdTask();
+}
+
 void TagFetcher::slotAcoustIdTaskNetworkError(
         QUrl requestUrl,
         QNetworkReply::NetworkError errorCode,
@@ -158,6 +172,10 @@ void TagFetcher::slotAcoustIdTaskNetworkError(
             "AcoustID",
             errorString,
             errorCode);
+}
+
+void TagFetcher::slotMusicBrainzTaskAborted() {
+    abortMusicBrainzTask();
 }
 
 void TagFetcher::slotMusicBrainzTaskNetworkError(

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -156,7 +156,10 @@ void TagFetcher::slotAcoustIdTaskFailed(
 }
 
 void TagFetcher::slotAcoustIdTaskAborted() {
-    abortAcoustIdTask();
+    VERIFY_OR_DEBUG_ASSERT(!m_pAcoustIdTask) {
+        // This should have been called before
+        abortAcoustIdTask();
+    }
 }
 
 void TagFetcher::slotAcoustIdTaskNetworkError(
@@ -175,7 +178,10 @@ void TagFetcher::slotAcoustIdTaskNetworkError(
 }
 
 void TagFetcher::slotMusicBrainzTaskAborted() {
-    abortMusicBrainzTask();
+    VERIFY_OR_DEBUG_ASSERT(!m_pMusicBrainzTask) {
+        // This should have been called before
+        abortMusicBrainzTask();
+    }
 }
 
 void TagFetcher::slotMusicBrainzTaskNetworkError(

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -45,6 +45,7 @@ class TagFetcher : public QObject {
             QList<QUuid> recordingIds);
     void slotAcoustIdTaskFailed(
             mixxx::network::JsonWebResponse response);
+    void slotAcoustIdTaskAborted();
     void slotAcoustIdTaskNetworkError(
             QUrl requestUrl,
             QNetworkReply::NetworkError errorCode,
@@ -57,6 +58,7 @@ class TagFetcher : public QObject {
             mixxx::network::WebResponse response,
             int errorCode,
             QString errorMessage);
+    void slotMusicBrainzTaskAborted();
     void slotMusicBrainzTaskNetworkError(
             QUrl requestUrl,
             QNetworkReply::NetworkError errorCode,

--- a/src/musicbrainz/web/acoustidlookuptask.cpp
+++ b/src/musicbrainz/web/acoustidlookuptask.cpp
@@ -3,6 +3,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QMetaMethod>
+#include <QTimerEvent>
 
 #include "musicbrainz/gzip.h"
 #include "util/assert.h"
@@ -226,6 +227,21 @@ void AcoustIdLookupTask::emitSucceeded(
         QList<QUuid>&& recordingIds) {
     DEBUG_ASSERT(isSignalFuncConnected(&AcoustIdLookupTask::succeeded));
     emit succeeded(std::move(recordingIds));
+}
+
+void AcoustIdLookupTask::timerEvent(QTimerEvent* event) {
+    const auto timerId = event->timerId();
+    if (timerId != m_timeoutTimerId) {
+        // ignore
+        return;
+    }
+    kLogger.info()
+            << "AcoustId lookup timed out";
+    onNetworkError(
+            QUrl(),
+            QNetworkReply::TimeoutError,
+            "AcoustId lookup timed out",
+            QByteArray());
 }
 
 } // namespace mixxx

--- a/src/musicbrainz/web/acoustidlookuptask.cpp
+++ b/src/musicbrainz/web/acoustidlookuptask.cpp
@@ -209,17 +209,23 @@ void AcoustIdLookupTask::onFinished(
     emitSucceeded(std::move(recordingIds));
 }
 
+void AcoustIdLookupTask::onFinishedCustom(
+        network::CustomWebResponse response) {
+    kLogger.warning()
+            << "Unexpected custom response received"
+            << response.replyUrl
+            << response.statusCode
+            << response.content;
+    network::JsonWebResponse jResponse;
+    jResponse.replyUrl = response.replyUrl;
+    jResponse.statusCode = response.statusCode;
+    emitFailed(std::move(jResponse));
+}
+
 void AcoustIdLookupTask::emitSucceeded(
         QList<QUuid>&& recordingIds) {
-    const auto signal = QMetaMethod::fromSignal(
-            &AcoustIdLookupTask::succeeded);
-    DEBUG_ASSERT(receivers(signal.name()) <= 1); // unique connection
-    if (isSignalConnected(signal)) {
-        emit succeeded(
-                std::move(recordingIds));
-    } else {
-        deleteLater();
-    }
+    DEBUG_ASSERT(isSignalFuncConnected(&AcoustIdLookupTask::succeeded));
+    emit succeeded(std::move(recordingIds));
 }
 
 } // namespace mixxx

--- a/src/musicbrainz/web/acoustidlookuptask.h
+++ b/src/musicbrainz/web/acoustidlookuptask.h
@@ -30,6 +30,8 @@ class AcoustIdLookupTask : public network::JsonWebTask {
             const QUrl& url,
             const QJsonDocument& content) override;
 
+    void timerEvent(QTimerEvent* event) override;
+
   private:
     void onFinished(
             network::JsonWebResponse response) override;

--- a/src/musicbrainz/web/acoustidlookuptask.h
+++ b/src/musicbrainz/web/acoustidlookuptask.h
@@ -33,6 +33,8 @@ class AcoustIdLookupTask : public network::JsonWebTask {
   private:
     void onFinished(
             network::JsonWebResponse response) override;
+    void onFinishedCustom(
+            network::CustomWebResponse response) override;
 
     void emitSucceeded(
             QList<QUuid>&& recordingIds);

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -195,31 +195,19 @@ void MusicBrainzRecordingsTask::slotNetworkReplyFinished() {
 
 void MusicBrainzRecordingsTask::emitSucceeded(
         QList<musicbrainz::TrackRelease>&& trackReleases) {
-    const auto signal = QMetaMethod::fromSignal(
-            &MusicBrainzRecordingsTask::succeeded);
-    DEBUG_ASSERT(receivers(signal.name()) <= 1); // unique connection
-    if (isSignalConnected(signal)) {
-        emit succeeded(
-                std::move(trackReleases));
-    } else {
-        deleteLater();
-    }
+    DEBUG_ASSERT(isSignalFuncConnected(&MusicBrainzRecordingsTask::succeeded));
+    emit succeeded(std::move(trackReleases));
 }
+
 void MusicBrainzRecordingsTask::emitFailed(
         network::WebResponse response,
         int errorCode,
         QString errorMessage) {
-    const auto signal = QMetaMethod::fromSignal(
-            &MusicBrainzRecordingsTask::succeeded);
-    DEBUG_ASSERT(receivers(signal.name()) <= 1); // unique connection
-    if (isSignalConnected(signal)) {
-        emit failed(
-                response,
-                errorCode,
-                errorMessage);
-    } else {
-        deleteLater();
-    }
+    DEBUG_ASSERT(isSignalFuncConnected(&MusicBrainzRecordingsTask::failed));
+    emit failed(
+            response,
+            errorCode,
+            errorMessage);
 }
 
 } // namespace mixxx

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -133,10 +133,12 @@ void MusicBrainzRecordingsTask::slotNetworkReplyFinished() {
     auto* const networkReply = networkReplyWithStatusCode.first;
     if (!networkReply) {
         // already aborted
+        emitFailed(network::WebResponse(), -1, "already aborted");
         return;
     }
     const auto statusCode = networkReplyWithStatusCode.second;
     VERIFY_OR_DEBUG_ASSERT(networkReply == m_pendingNetworkReply) {
+        emitFailed(network::WebResponse(), -1, "Assertion failed");
         return;
     }
     m_pendingNetworkReply = nullptr;
@@ -175,7 +177,12 @@ void MusicBrainzRecordingsTask::slotNetworkReplyFinished() {
     if (!recordingsResult.second) {
         kLogger.warning()
                 << "Failed to parse XML response";
-        slotAbort();
+        emitFailed(
+                network::WebResponse(
+                        networkReply->url(),
+                        statusCode),
+                -1,
+                "Failed to parse XML response");
         return;
     }
 

--- a/src/musicbrainz/web/musicbrainzrecordingstask.cpp
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.cpp
@@ -2,6 +2,7 @@
 
 #include <QMetaMethod>
 #include <QThread>
+#include <QTimerEvent>
 #include <QXmlStreamReader>
 
 #include "defs_urls.h"
@@ -215,6 +216,21 @@ void MusicBrainzRecordingsTask::emitFailed(
             response,
             errorCode,
             errorMessage);
+}
+
+void MusicBrainzRecordingsTask::timerEvent(QTimerEvent* event) {
+    const auto timerId = event->timerId();
+    if (timerId != m_timeoutTimerId) {
+        // ignore
+        return;
+    }
+    kLogger.info()
+            << "MusicBrainz recordings lookup timed out";
+    onNetworkError(
+            QUrl(),
+            QNetworkReply::TimeoutError,
+            "MusicBrainz recordings lookup timed out",
+            QByteArray());
 }
 
 } // namespace mixxx

--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -29,6 +29,9 @@ class MusicBrainzRecordingsTask : public network::WebTask {
             int errorCode,
             QString errorMessage);
 
+  protected:
+    void timerEvent(QTimerEvent* event) override;
+
   private slots:
     void slotNetworkReplyFinished();
 

--- a/src/network/jsonwebtask.cpp
+++ b/src/network/jsonwebtask.cpp
@@ -103,26 +103,6 @@ JsonWebTask::~JsonWebTask() {
     }
 }
 
-void JsonWebTask::onFinished(
-        JsonWebResponse response) {
-    kLogger.info()
-            << "Response received"
-            << response.replyUrl
-            << response.statusCode
-            << response.content;
-    deleteAfterFinished();
-}
-
-void JsonWebTask::onFinishedCustom(
-        CustomWebResponse response) {
-    kLogger.info()
-            << "Custom response received"
-            << response.replyUrl
-            << response.statusCode
-            << response.content;
-    deleteAfterFinished();
-}
-
 QNetworkReply* JsonWebTask::sendNetworkRequest(
         QNetworkAccessManager* networkAccessManager,
         HttpRequestMethod method,
@@ -281,15 +261,8 @@ void JsonWebTask::slotNetworkReplyFinished() {
 
 void JsonWebTask::emitFailed(
         network::JsonWebResponse response) {
-    const auto signal = QMetaMethod::fromSignal(
-            &JsonWebTask::failed);
-    DEBUG_ASSERT(receivers(signal.name()) <= 1); // unique connection
-    if (isSignalConnected(signal)) {
-        emit failed(
-                std::move(response));
-    } else {
-        deleteLater();
-    }
+    DEBUG_ASSERT(&JsonWebTask::failed);
+    emit failed(std::move(response));
 }
 
 } // namespace network

--- a/src/network/jsonwebtask.h
+++ b/src/network/jsonwebtask.h
@@ -77,12 +77,11 @@ class JsonWebTask : public WebTask {
 
   private:
     // Handle the response and ensure that the task eventually
-    // gets deleted. The default implementation discards the
-    // response and deletes the task.
+    // gets deleted.
     virtual void onFinished(
-            JsonWebResponse response);
+            JsonWebResponse response) = 0;
     virtual void onFinishedCustom(
-            CustomWebResponse response);
+            CustomWebResponse response) = 0;
 
     bool doStart(
             QNetworkAccessManager* networkAccessManager,

--- a/src/network/jsonwebtask.h
+++ b/src/network/jsonwebtask.h
@@ -63,6 +63,7 @@ class JsonWebTask : public WebTask {
 
   private slots:
     void slotNetworkReplyFinished();
+    void slotNetworkReplyError(QNetworkReply::NetworkError);
 
   protected:
     // Customizable in derived classes

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -177,23 +177,6 @@ void WebTask::slotAbort() {
     doAbort();
 }
 
-void WebTask::timerEvent(QTimerEvent* event) {
-    DEBUG_ASSERT(thread() == QThread::currentThread());
-    const auto timerId = event->timerId();
-    DEBUG_ASSERT(timerId != kInvalidTimerId);
-    if (timerId != m_timeoutTimerId) {
-        // ignore
-        return;
-    }
-    kLogger.info()
-            << "Timed out";
-    onNetworkError(
-            QUrl(),
-            QNetworkReply::TimeoutError,
-            "Timed out",
-            QByteArray());
-}
-
 QPair<QNetworkReply*, HttpStatusCode> WebTask::receiveNetworkReply() {
     DEBUG_ASSERT(thread() == QThread::currentThread());
     auto* const networkReply = qobject_cast<QNetworkReply*>(sender());

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -209,7 +209,6 @@ QPair<QNetworkReply*, HttpStatusCode> WebTask::receiveNetworkReply() {
     }
 
     if (m_abort) {
-        onAborted();
         return qMakePair(nullptr, statusCode);
     }
 

--- a/src/network/webtask.cpp
+++ b/src/network/webtask.cpp
@@ -62,8 +62,8 @@ WebTask::WebTask(
         QNetworkAccessManager* networkAccessManager,
         QObject* parent)
         : QObject(parent),
-          m_networkAccessManager(networkAccessManager),
           m_timeoutTimerId(kInvalidTimerId),
+          m_networkAccessManager(networkAccessManager),
           m_abort(false) {
     std::call_once(registerMetaTypesOnceFlag, registerMetaTypesOnce);
     DEBUG_ASSERT(m_networkAccessManager);

--- a/src/network/webtask.h
+++ b/src/network/webtask.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QMetaMethod>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QPair>
@@ -98,10 +99,6 @@ class WebTask : public QObject {
     // Cancel a pending request.
     void invokeAbort();
 
-    // Abort the pending request while suppressing any signals
-    // and mark the task for deletion.
-    void deleteBeforeFinished();
-
     // Disconnect from all signals after receiving a reply
     // and mark the task for deletion.
     void deleteAfterFinished();
@@ -142,6 +139,12 @@ class WebTask : public QObject {
             QByteArray errorContent);
 
     QPair<QNetworkReply*, HttpStatusCode> receiveNetworkReply();
+
+    template<typename Func>
+    bool isSignalFuncConnected(Func signalFunc) {
+        const QMetaMethod signal = QMetaMethod::fromSignal(signalFunc);
+        return isSignalConnected(signal);
+    }
 
   private:
     virtual bool doStart(

--- a/src/network/webtask.h
+++ b/src/network/webtask.h
@@ -122,7 +122,6 @@ class WebTask : public QObject {
             QByteArray errorContent);
 
   protected:
-    void timerEvent(QTimerEvent* event) override;
 
     // Handle an aborted request and ensure that the task eventually
     // gets deleted. The default implementation simply deletes the
@@ -146,6 +145,8 @@ class WebTask : public QObject {
         return isSignalConnected(signal);
     }
 
+    int m_timeoutTimerId;
+
   private:
     virtual bool doStart(
             QNetworkAccessManager* networkAccessManager,
@@ -155,8 +156,6 @@ class WebTask : public QObject {
     // All member variables must only be accessed from
     // the event loop thread!!
     const QPointer<QNetworkAccessManager> m_networkAccessManager;
-
-    int m_timeoutTimerId;
     bool m_abort;
 };
 


### PR DESCRIPTION
Here is the PR that fixes the crash. 

The crash happens due to situation where the webtask has deleted itself due to errors, without notice of the TagFetcher. My first attempt was to fix it with a QPointer, but than the GUI stalls in these situations instead of a crash. 
 
So I have reworked the code in a way that the WebTask ALWAYS returns with a signal. 

There was also an issue when the WebTAsk aborts itself. I have solved this by replacing these places with a failed signal. Now abort is only issues from the TagFetcher.

During development i have connected the aborted() signal. This is now unnecessary because the WebTask is disconnected before. I have kept this signal for debug purpose and decorated it with an assertion. 

There is one pending issue that the third request returns a Timeout. I did not managed to find the cause. Maybe it is a kind of abuse protection.  The error signal is not issued at least.
I have introduced a meaningful error message which can be approved even more if we know the cause.  


This was tested on Xenial with Qt 5.5.1. 




 
